### PR TITLE
Feature - Direct reload

### DIFF
--- a/src/it/uknowngino/moddedintegration/implementation/V1_12_Implementation.java
+++ b/src/it/uknowngino/moddedintegration/implementation/V1_12_Implementation.java
@@ -1,10 +1,10 @@
 package it.uknowngino.moddedintegration.implementation;
 
 import it.uknowngino.moddedintegration.constructors.PopulationResult;
+import it.uknowngino.moddedintegration.main.ModdedIntegration;
 import it.uknowngino.moddedintegration.utils.IntegrationUtils;
 import it.uknowngino.moddedintegration.utils.LogUtils;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 
 import java.io.BufferedWriter;
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 
 public class V1_12_Implementation implements PopulationImplementation {
 
-    private final File itemsFile = new File(Bukkit.getPluginManager().getPlugin("Essentials").getDataFolder() + File.separator + getItemsFileName());
+    private final File itemsFile = new File(ModdedIntegration.getEssentials().getDataFolder() + File.separator + getItemsFileName());
 
     @Override
     public String getItemsFileName() {

--- a/src/it/uknowngino/moddedintegration/main/ModdedIntegration.java
+++ b/src/it/uknowngino/moddedintegration/main/ModdedIntegration.java
@@ -1,11 +1,13 @@
 package it.uknowngino.moddedintegration.main;
 
+import com.earth2me.essentials.Essentials;
 import it.uknowngino.moddedintegration.commands.ModdedIntegrationCommand;
 import it.uknowngino.moddedintegration.config.Config;
 import it.uknowngino.moddedintegration.enums.ServerVersion;
 import it.uknowngino.moddedintegration.utils.IntegrationUtils;
 import it.uknowngino.moddedintegration.utils.LogUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.logging.Level;
@@ -13,13 +15,18 @@ import java.util.logging.Level;
 public class ModdedIntegration extends JavaPlugin {
 
 	public static final ServerVersion SERVER_VERSION = ServerVersion.getCurrentServerVersion();
+	public static final PluginManager PLUGIN_MANAGER = Bukkit.getPluginManager();
+
 	private static ModdedIntegration plugin;
+	private static Essentials essentials;
 
 	public void onEnable() {
 		
 		plugin = this;
 		
-		if(Bukkit.getPluginManager().isPluginEnabled("Essentials")) {
+		if(PLUGIN_MANAGER.isPluginEnabled("Essentials")) {
+
+			essentials = (Essentials) PLUGIN_MANAGER.getPlugin("Essentials");
 
 			Config.reload();
 			IntegrationUtils.populateItemsFile();
@@ -30,7 +37,7 @@ public class ModdedIntegration extends JavaPlugin {
 		} else {
 
 			LogUtils.log(Level.SEVERE, "EssentialsX was not found in enabled plugins! Disabling ModdedIntegration...");
-			Bukkit.getPluginManager().disablePlugin(this);
+			PLUGIN_MANAGER.disablePlugin(this);
 			
 		}
 
@@ -52,6 +59,12 @@ public class ModdedIntegration extends JavaPlugin {
 		
 		return plugin;
 		
+	}
+
+	public static Essentials getEssentials() {
+
+		return essentials;
+
 	}
 
 }

--- a/src/it/uknowngino/moddedintegration/main/ModdedIntegration.java
+++ b/src/it/uknowngino/moddedintegration/main/ModdedIntegration.java
@@ -31,7 +31,8 @@ public class ModdedIntegration extends JavaPlugin {
 			Config.reload();
 			IntegrationUtils.populateItemsFile();
 
-			registerCommands();
+			getCommand("moddedintegration").setExecutor(new ModdedIntegrationCommand());
+
 			LogUtils.log(Level.INFO, "The plugin has been enabled successfully with Implementation " + SERVER_VERSION + ".");
 
 		} else {
@@ -47,12 +48,6 @@ public class ModdedIntegration extends JavaPlugin {
 
 		LogUtils.log(Level.INFO, "The plugin has been disabled.");
 		
-	}
-
-	private void registerCommands() {
-
-		getCommand("moddedintegration").setExecutor(new ModdedIntegrationCommand());
-
 	}
 
 	public static ModdedIntegration getInstance() {

--- a/src/it/uknowngino/moddedintegration/utils/IntegrationUtils.java
+++ b/src/it/uknowngino/moddedintegration/utils/IntegrationUtils.java
@@ -5,15 +5,16 @@ import it.uknowngino.moddedintegration.config.Config;
 import it.uknowngino.moddedintegration.constructors.PopulationResult;
 import it.uknowngino.moddedintegration.implementation.PopulationImplementation;
 import it.uknowngino.moddedintegration.main.ModdedIntegration;
-//import org.apache.commons.io.IOUtils;
 import org.bukkit.Bukkit;
-import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.scheduler.BukkitScheduler;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.logging.Level;
 
+import static it.uknowngino.moddedintegration.main.ModdedIntegration.PLUGIN_MANAGER;
 import static it.uknowngino.moddedintegration.main.ModdedIntegration.SERVER_VERSION;
 
 public class IntegrationUtils {
@@ -21,10 +22,9 @@ public class IntegrationUtils {
 	static { assert SERVER_VERSION != null; }
 	public static final PopulationImplementation IMPLEMENTATION = SERVER_VERSION.getImplementation();
 
-	public static final File ITEMS_FILE = new File(Bukkit.getPluginManager().getPlugin("Essentials").getDataFolder() + File.separator + IMPLEMENTATION.getItemsFileName());
+	public static final File ITEMS_FILE = new File(ModdedIntegration.getEssentials().getDataFolder() + File.separator + IMPLEMENTATION.getItemsFileName());
 
 	private static final BukkitScheduler SCHEDULER = Bukkit.getScheduler();
-	private static final ConsoleCommandSender CONSOLE_SENDER = Bukkit.getConsoleSender();
 
 	public static PopulationResult populateItemsFile() {
 
@@ -49,7 +49,7 @@ public class IntegrationUtils {
 		} else {
 			
 			LogUtils.log(Level.SEVERE, "EssentialsX's " + IMPLEMENTATION.getItemsFileName() + " can't be found! Disabling ModdedIntegration...");
-			Bukkit.getPluginManager().disablePlugin(ModdedIntegration.getInstance());
+			PLUGIN_MANAGER.disablePlugin(ModdedIntegration.getInstance());
 			
 		}
 
@@ -68,7 +68,6 @@ public class IntegrationUtils {
 				if(ITEMS_FILE.exists() && ITEMS_FILE.delete()) {
 
 					Files.copy(defaultFile, ITEMS_FILE.toPath());
-					//IOUtils.copy(defaultFile, new FileOutputStream(ITEMS_FILE));
 					LogUtils.log(Level.INFO, "The EssentialsX's " + IMPLEMENTATION.getItemsFileName() + " file has been reset to the default values. Reloading EssentialsX...");
 					reloadEssentials();
 
@@ -98,7 +97,7 @@ public class IntegrationUtils {
 
 	public static void reloadEssentials() {
 
-		SCHEDULER.runTaskLater(ModdedIntegration.getInstance(), () -> Bukkit.dispatchCommand(CONSOLE_SENDER, "essentials reload"), Config.reload_delay);
+		SCHEDULER.runTaskLater(ModdedIntegration.getInstance(), () -> ModdedIntegration.getEssentials().reload(), Config.reload_delay);
 
 	}
 


### PR DESCRIPTION
Changes the way Essentials is reloaded. Before this, essentials was reloaded executing /essentials reload in console via ModdedIntegration, which is a very bad way of doing things. With this new feature PR, essentials is now reloaded directly accessing the methods used by the plugin command itself (Essentials::reload).